### PR TITLE
Handle exception where sclang sends wrong requestId

### DIFF
--- a/lib/nodejs/scapi.js
+++ b/lib/nodejs/scapi.js
@@ -57,7 +57,11 @@ SCAPI.prototype.connect = function() {
     if (msg.address === '/API/reply') {
       return self.receive('reply', msg);
     }
-    return self.receive('scapi_error', msg);
+    try{
+      return self.receive('scapi_error', msg);
+    }catch(e){
+      self.log.err('sclang returned invalid requestId: ' + msg.args[1].value);
+    }
   });
 
   this.udp.on('error', function(e) {


### PR DESCRIPTION
I have a (separate) issue with JSON parsing in API, that led me to discover this:

If the requestId returned by sclang isn't correct, it will throw an error that isn't actually caught elsewhere. This crashes node.

For example, I've been seeing return messages from sclang like this on error:
{"address":"/API/error","args":[{"type":"float","value":0},{"type":"string","value":"1,1:3"},{"type":"string","value":"ERROR: Message 'name' not understood."}],"oscType":"message"}

I dunno where "1,1:3" came from, and I guess this shouldn't really happen as long as you aren't sending a crazy request.

My only concern with pushing this is that the request won't get deleted from the array, which is a memory leak. Is it better to crash the app or to knowingly leak memory?