### PR TITLE
install was failing due to bin entry in package.json

### DIFF
--- a/packages/lang/package.json
+++ b/packages/lang/package.json
@@ -32,8 +32,8 @@
     "url": "git+https://github.com/crucialfelix/supercolliderjs.git"
   },
   "bin": {
-    "supercollider": "node ./lib/bin/sclang.js",
-    "compile-synthdefs": "node ./lib/bin/compile-synthdefs.js"
+    "supercollider": "./lib/bin/sclang.js",
+    "compile-synthdefs": "./lib/bin/compile-synthdefs.js"
   },
   "scripts": {
     "build": "tsc -b . && npm run copy",


### PR DESCRIPTION
Install was failing:

```
$ npm install --save @supercollider/lang
npm WARN babel-eslint@10.0.3 requires a peer of eslint@>= 4.12.1 but none is installed. You must install peer dependencies yourself.

npm ERR! path /Users/colin/Projects/supercollider-redux/node_modules/@supercollider/lang/node ./lib/bin/sclang.js
npm ERR! code ENOENT
npm ERR! errno -2
npm ERR! syscall chmod
npm ERR! enoent ENOENT: no such file or directory, chmod '/Users/colin/Projects/supercollider-redux/node_modules/@supercollider/lang/node ./lib/bin/sclang.js'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/colin/.npm/_logs/2019-11-04T00_50_17_512Z-debug.log
```