### PR TITLE
Bugfix where response values aren't in an object with a `value`.

### DIFF
--- a/packages/scapi/src/index.ts
+++ b/packages/scapi/src/index.ts
@@ -133,8 +133,8 @@ export default class SCAPI extends events.EventEmitter {
   }
 
   receive(signal, msg): void {
-    const requestId = msg.args[1].value;
-    let result = msg.args[2].value;
+    const requestId = msg.args[1];
+    let result = msg.args[2];
     const request = this.requests[requestId];
     if (!request) {
       this.emit("error", "Unknown request " + requestId);


### PR DESCRIPTION
This makes the scapi module able to make use of "replies" from an API.  Otherwise it would fail with:

```
error  : Unknown request undefined
```

Because the `msg` argument looks like:

```js
{ address: '/API/reply',
  args:
   [ 0,
     'ck2unqfsm0004mebg69u27ehi',
     '{"result": {"status": "ok"}}' ],
  oscType: 'message' }
```

@crucialfelix does this look right to you?

Here are the relevant lines in the API quark:

https://github.com/supercollider-quarks/API/blob/master/API.sc#L236-L237